### PR TITLE
Minor bug fix with copying .dll files.

### DIFF
--- a/manual-bwapi4/Mirror.java
+++ b/manual-bwapi4/Mirror.java
@@ -74,14 +74,20 @@ public class Mirror {
                 String path = Mirror.class.getProtectionDomain().getCodeSource().getLocation().getPath();
                 String decodedPath = java.net.URLDecoder.decode(path, "UTF-8");
 
+                JarResources jar = null;
                 for (String dllName : dllNames) {
                     String dllNameExt = dllName + ".dll";
                     if (!new File(dllNameExt).exists()) {
-                        JarResources jar = new JarResources(decodedPath);
+                        if (null == jar) {
+                            jar = new JarResources(decodedPath);
+                        }
                         byte[] correctDllData = jar.getResource(dllNameExt);
-                        FileOutputStream funnyStream = new FileOutputStream(dllNameExt);
-                        funnyStream.write(correctDllData);
-                        funnyStream.close();
+                        // prevents the creation of zero byte files
+                        if (null != correctDllData) {
+                            FileOutputStream funnyStream = new FileOutputStream(dllNameExt);
+                            funnyStream.write(correctDllData);
+                            funnyStream.close();
+                        }
                     }
                 }
             }

--- a/manual-bwapi4/Mirror.java
+++ b/manual-bwapi4/Mirror.java
@@ -77,7 +77,7 @@ public class Mirror {
                 for (String dllName : dllNames) {
                     String dllNameExt = dllName + ".dll";
                     if (!new File(dllNameExt).exists()) {
-                        JarResources jar = new JarResources(path);
+                        JarResources jar = new JarResources(decodedPath);
                         byte[] correctDllData = jar.getResource(dllNameExt);
                         FileOutputStream funnyStream = new FileOutputStream(dllNameExt);
                         funnyStream.write(correctDllData);


### PR DESCRIPTION
Just makes sure that the decodedPath is being used when creation JarResources so that whitespace and other fun characters will not cause an issue.

Made a minor improvement by prevent JarResource from being created more than once. Also, if for some reason a file is not found, do not create a zero byte version of it.

Sorry about the other request. By the way what is the minimum level of Java you are aiming to support?
